### PR TITLE
Fix Gacha Stretch Issue

### DIFF
--- a/src/components/card/gacha.vue
+++ b/src/components/card/gacha.vue
@@ -1,12 +1,10 @@
 <template>
   <div>
-    <q-card inline>
+    <q-card>
       <q-card-title class="bg-pink text-white">
         {{data.gachaName}}
       </q-card-title>
-      <q-card-media>
-        <img v-lazy="`/assets-${server}/gacha/screen/${data.resourceName}_logo.png`" class="responsive" style="max-height: 140px;" />
-      </q-card-media>
+      <q-card-media class="gacha-img" v-lazy:background-image="`/assets-${server}/gacha/screen/${data.resourceName}_logo.png`"></q-card-media>
       <q-card-main>
         <h5 class="q-my-sm" v-if="Number(data.publishedAt) > Date.now()">{{$t('not-started')}}<br>{{(new Date(Number(data.publishedAt))).toLocaleString()}}</h5>
         <count-down :target-time="Number(data.closedAt)" v-else></count-down>
@@ -40,4 +38,9 @@ export default {
 </script>
 
 <style lang="stylus" scoped>
+.gacha-img
+  height 140px
+  background-size contain
+  background-repeat no-repeat
+  background-position center
 </style>


### PR DESCRIPTION
## Motivation

Fix gacha page's image stretch issue.

## Preview

Before:
![](https://cdn.discordapp.com/attachments/472361967013855244/473276216275894273/20180730_084808.JPG)

After:
<img width="546" alt="image" src="https://user-images.githubusercontent.com/5436953/43372850-5ed53096-9373-11e8-98e2-1a25401cdb10.png">
