### PR TITLE
Fix Multiple Gacha Descriptions & Remove Extraneous `"`

### DIFF
--- a/src/components/modals/gacha.vue
+++ b/src/components/modals/gacha.vue
@@ -19,7 +19,6 @@
         <h6>{{$t('gacha.desc')}}</h6>
         <p>{{gacha.description}}</p>
         <p v-if="gacha.information && gacha.information.description" v-html="gacha.information.description.replace(/\n/g, '<br>')"></p>
-        <p v-else>{{gacha.description}}</p>
         <h6 v-if="gacha.information && gacha.information.newMemberInfo">{{$t('gacha.new-members')}}</h6>
         <p v-if="gacha.information && gacha.information.newMemberInfo" v-html="gacha.information.newMemberInfo.replace(/\n/g, '<br>')"></p>
         <h6>{{$t('gacha.rates')}}</h6>

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -70,7 +70,7 @@ export default {
     'list-title': '{srv} Scouts List',
     'list-count': 'Counts',
     'start-at': 'Start at:',
-    'end-at': 'Close at:"',
+    'end-at': 'Close at:',
     'desc': 'Description',
     'new-members': 'New members',
     'rates': 'Gacha rates',


### PR DESCRIPTION
## Motivation

1. Extra `"` mark in English translation.
2. Duplication of gacha description in Korean and International servers.

## Preview

Before:
<img width="542" alt="image" src="https://user-images.githubusercontent.com/5436953/43373258-83378da0-9376-11e8-9e4e-349f882ae9ce.png">

After:
<img width="552" alt="image" src="https://user-images.githubusercontent.com/5436953/43373269-91b35620-9376-11e8-86f0-4c3cb07303a1.png">
