### PR TITLE
Update Linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 before_script:
 - npm install -g quasar-cli
 script:
-- eslint src
 - quasar build -m pwa
 before_deploy:
 - openssl aes-256-cbc -K $encrypted_6471c10cdc2d_key -iv $encrypted_6471c10cdc2d_iv

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 before_script:
 - npm install -g quasar-cli
 script:
-- quasar lint
+- eslint src
 - quasar build -m pwa
 before_deploy:
 - openssl aes-256-cbc -K $encrypted_6471c10cdc2d_key -iv $encrypted_6471c10cdc2d_iv

--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ $ quasar dev
 $ quasar build
 
 # lint code
-$ quasar lint
+$ eslint src
 ```


### PR DESCRIPTION
Why remove `quasar lint` in `.travis.yml`: According to the tutorial here: https://quasar-framework.org/guide/app-linter.html, `eslinter` is enabled by default when building.